### PR TITLE
Podcast file support

### DIFF
--- a/panopto-embed-handler.php
+++ b/panopto-embed-handler.php
@@ -34,3 +34,10 @@ function wp_embed_handler_panopto( $matches, $attr, $url, $rawattr ) {
 
 	return apply_filters( 'embed_panopto', $embed, $matches, $attr, $url, $rawattr );
 }
+
+wp_embed_register_handler( 'panopto_podcast', '#https?:\/\/(.*)Panopto\/Podcast\/(.*)#i', 'wp_embed_handler_panopto_podcast' );
+
+function wp_embed_handler_panopto_podcast( $matches, $attr, $url, $rawattr ) {
+	$audio = sprintf( '<audio style="visibility:visible;" src="%s" controls="controls">', esc_url( $url ) );
+	return apply_filters( 'wp_embed_handler_audio', $audio, $attr, $url, $rawattr );
+}

--- a/panopto-embed-handler.php
+++ b/panopto-embed-handler.php
@@ -35,9 +35,9 @@ function wp_embed_handler_panopto( $matches, $attr, $url, $rawattr ) {
 	return apply_filters( 'embed_panopto', $embed, $matches, $attr, $url, $rawattr );
 }
 
-wp_embed_register_handler( 'panopto_podcast', '#https?:\/\/(.*)Panopto\/Podcast\/(StreamInBrowser|Download)\/(.*)#i', 'wp_embed_handler_panopto_podcast' );
+wp_embed_register_handler( 'panopto_podcast_file', '#https?:\/\/(.*)Panopto\/Podcast\/(StreamInBrowser|Download)\/(.*)#i', 'wp_embed_handler_panopto_podcast_file' );
 
-function wp_embed_handler_panopto_podcast( $matches, $attr, $url, $rawattr ) {
+function wp_embed_handler_panopto_podcast_file( $matches, $attr, $url, $rawattr ) {
 	$audio = sprintf( '<audio style="visibility:visible;" src="%s" controls="controls">', esc_url( $url ) );
 	return apply_filters( 'wp_embed_handler_audio', $audio, $attr, $url, $rawattr );
 }

--- a/panopto-embed-handler.php
+++ b/panopto-embed-handler.php
@@ -35,7 +35,7 @@ function wp_embed_handler_panopto( $matches, $attr, $url, $rawattr ) {
 	return apply_filters( 'embed_panopto', $embed, $matches, $attr, $url, $rawattr );
 }
 
-wp_embed_register_handler( 'panopto_podcast', '#https?:\/\/(.*)Panopto\/Podcast\/(.*)#i', 'wp_embed_handler_panopto_podcast' );
+wp_embed_register_handler( 'panopto_podcast', '#https?:\/\/(.*)Panopto\/Podcast\/(StreamInBrowser|Download)\/(.*)#i', 'wp_embed_handler_panopto_podcast' );
 
 function wp_embed_handler_panopto_podcast( $matches, $attr, $url, $rawattr ) {
 	$audio = sprintf( '<audio style="visibility:visible;" src="%s" controls="controls">', esc_url( $url ) );


### PR DESCRIPTION
This PR allows users to embed a link directly to a media item's Podcast audio file (found on the Panopto "Outputs" screen for an item) and have it show up in WordPress as an `<audio>` HTML element. Some of our users have found this useful for sharing audio that is hosted in Panopto without all of the additional iframes and players.